### PR TITLE
Finished working on the “changing-bytecode” project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -86,3 +86,9 @@
 [submodule "projects/custom-rng/lib/openzeppelin-contracts"]
 	path = projects/custom-rng/lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts
+[submodule "projects/changing-bytecode/lib/forge-std"]
+	path = projects/changing-bytecode/lib/forge-std
+	url = https://github.com/foundry-rs/forge-std
+[submodule "projects/changing-bytecode/lib/openzeppelin-contracts"]
+	path = projects/changing-bytecode/lib/openzeppelin-contracts
+	url = https://github.com/OpenZeppelin/openzeppelin-contracts


### PR DESCRIPTION
- When redeploying via create2 after selfdestruct, if the value of an immutable variable is changed, the address may be the same but the bytecode is different
- Therefore, using bytecode as a contract identifier is a very dangerous thing that is a point of hacking.
- Fortunately, EIP-6780 is reflected in the cancun update, and in the case of a selfdestructed address, it is not possible to create the same address through create2, making it more secure.

Translated with DeepL.com (free version)